### PR TITLE
pingxelflut: Fix compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ HEADER_FBDEV = linuxfb.h
 
 SOURCE_PINGXELFLUT = network_pingxelflut.c
 HEADER_PINGXELFLUT = network_pingxelflut.h
+DEPS_PINGXELFLUT = libbpf
+LDFLAGS_libbpf = -lbpf
 
 DEPS_NUMA = numa
 LDFLAGS_numa = -lnuma

--- a/network_pingxelflut.c
+++ b/network_pingxelflut.c
@@ -16,7 +16,7 @@
 #include <sched.h>
 #include <stdarg.h>
 
-#include <linux/bpf.h>
+#include <bpf/bpf.h>
 
 #include "network_pingxelflut.h"
 #include "framebuffer.h"


### PR DESCRIPTION
The header used for bpf was not the right one. Additionally we need to link against libbpf, thus I've added it as a dependency of the pingxelflut feature.

Needs libbpf and libbpf-dev to compile. Tested on Debian experimental.